### PR TITLE
Add msgpack_src to pod source files

### DIFF
--- a/MsgPackSerialization.podspec
+++ b/MsgPackSerialization.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   s.social_media_url = 'https://twitter.com/mattt'
   s.authors  = { 'Mattt Thompson' => 'm@mattt.me' }
   s.source   = { :git => 'https://github.com/mattt/MsgPackSerialization.git', :tag => '0.0.1' }
-  s.source_files = 'MsgPackSerialization'
+  s.source_files = 'MsgPackSerialization', 'MsgPackSerialization/msgpack_src/*.{c,h}', 'MsgPackSerialization/msgpack_src/msgpack/*.h'
   s.requires_arc = true
 
   s.ios.deployment_target = '5.0'


### PR DESCRIPTION
I wanted to use the `AFMsgPackSerializer` with `AFNetworking` and I needed the `MsgPackSerialization` pod. I notice that the source and headers files from `msgpack_src` were not added and missed for the compilation.
I simply added those files to the pod spec.
