### PR TITLE
Add custom module map

### DIFF
--- a/MsgPackSerialization.podspec
+++ b/MsgPackSerialization.podspec
@@ -9,6 +9,7 @@ Pod::Spec.new do |s|
   s.source   = { :git => 'https://github.com/mattt/MsgPackSerialization.git', :tag => '0.0.2' }
   s.source_files = 'MsgPackSerialization', 'MsgPackSerialization/msgpack_src/*.{c,h}', 'MsgPackSerialization/msgpack_src/msgpack/*.h'
   s.requires_arc = true
+  s.public_header_files = 'MsgPackSerialization/MsgPackSerialization.h'
 
   s.ios.deployment_target = '5.0'
   s.osx.deployment_target = '10.7'


### PR DESCRIPTION
This commit adds custom module map, so that the pod can be built using cocoapods' `use_frameworks!` parameter. Solution for this found in https://github.com/rvi/msgpack-objective-C